### PR TITLE
Add migration runner and legacy-hash bridge for DB updates

### DIFF
--- a/src/php/classes/PDR/Database/Migration/LegacyHashBridgeMigration.php
+++ b/src/php/classes/PDR/Database/Migration/LegacyHashBridgeMigration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PDR\Database\Migration;
+
+class LegacyHashBridgeMigration implements MigrationInterface {
+
+    private $version;
+    private $description;
+    private $callback;
+
+    public function __construct(string $version, string $description, callable $callback) {
+        $this->version = $version;
+        $this->description = $description;
+        $this->callback = $callback;
+    }
+
+    public function getVersion(): string {
+        return $this->version;
+    }
+
+    public function getDescription(): string {
+        return $this->description;
+    }
+
+    public function up(): bool {
+        $result = call_user_func($this->callback);
+        return false !== $result;
+    }
+}

--- a/src/php/classes/PDR/Database/Migration/MigrationInterface.php
+++ b/src/php/classes/PDR/Database/Migration/MigrationInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PDR\Database\Migration;
+
+interface MigrationInterface {
+
+    public function getVersion(): string;
+
+    public function getDescription(): string;
+
+    public function up(): bool;
+}

--- a/src/php/classes/PDR/Database/Migration/MigrationRunner.php
+++ b/src/php/classes/PDR/Database/Migration/MigrationRunner.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PDR\Database\Migration;
+
+use PDO;
+use RuntimeException;
+
+class MigrationRunner {
+
+    private const LOCK_NAME = 'pdr_schema_migrations_lock';
+
+    /**
+     * @var \database_wrapper
+     */
+    private $databaseWrapper;
+
+    public function __construct(\database_wrapper $databaseWrapper) {
+        $this->databaseWrapper = $databaseWrapper;
+    }
+
+    public function runMigrations(array $migrations): void {
+        if ([] === $migrations) {
+            return;
+        }
+        $this->createSchemaMigrationsTableIfNecessary();
+        if (!$this->acquireLock()) {
+            throw new RuntimeException('Could not acquire migration lock.');
+        }
+        try {
+            foreach ($migrations as $migration) {
+                if (!$migration instanceof MigrationInterface) {
+                    throw new RuntimeException('Invalid migration type passed to MigrationRunner.');
+                }
+                if ($this->isApplied($migration->getVersion())) {
+                    continue;
+                }
+                if (false === $migration->up()) {
+                    throw new RuntimeException('Migration failed: ' . $migration->getVersion());
+                }
+                $this->markAsApplied($migration);
+            }
+        } finally {
+            $this->releaseLock();
+        }
+    }
+
+    private function createSchemaMigrationsTableIfNecessary(): void {
+        $sql_query = "CREATE TABLE IF NOT EXISTS `schema_migrations` (
+            `version` VARCHAR(191) NOT NULL,
+            `description` VARCHAR(255) NOT NULL,
+            `executed_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (`version`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+        $this->databaseWrapper->run($sql_query);
+    }
+
+    private function isApplied(string $version): bool {
+        $sql_query = "SELECT `version` FROM `schema_migrations` WHERE `version` = :version LIMIT 1;";
+        $result = $this->databaseWrapper->run($sql_query, array('version' => $version));
+        return false !== $result->fetch(PDO::FETCH_ASSOC);
+    }
+
+    private function markAsApplied(MigrationInterface $migration): void {
+        $sql_query = "INSERT INTO `schema_migrations` (`version`, `description`) VALUES (:version, :description);";
+        $this->databaseWrapper->run($sql_query, array(
+            'version' => $migration->getVersion(),
+            'description' => $migration->getDescription(),
+        ));
+    }
+
+    private function acquireLock(): bool {
+        $sql_query = "SELECT GET_LOCK(:lock_name, 30) AS lock_acquired;";
+        $result = $this->databaseWrapper->run($sql_query, array('lock_name' => self::LOCK_NAME));
+        $row = $result->fetch(PDO::FETCH_OBJ);
+        return isset($row->lock_acquired) && (int) $row->lock_acquired === 1;
+    }
+
+    private function releaseLock(): void {
+        $sql_query = "SELECT RELEASE_LOCK(:lock_name);";
+        $this->databaseWrapper->run($sql_query, array('lock_name' => self::LOCK_NAME));
+    }
+}

--- a/src/php/classes/class.update_database.php
+++ b/src/php/classes/class.update_database.php
@@ -25,6 +25,20 @@
 class update_database {
 
     public function __construct() {
+        require_once PDR_FILE_SYSTEM_APPLICATION_PATH . 'src/php/database_version_hash.php';
+        $migration_runner = new \PDR\Database\Migration\MigrationRunner(database_wrapper::instance());
+        $migration_runner->runMigrations(array(
+            new \PDR\Database\Migration\LegacyHashBridgeMigration(
+                'legacy-hash-' . PDR_DATABASE_VERSION_HASH,
+                'Bridge migration that applies legacy hash-based update_database() updates.',
+                function () {
+                    return $this->runLegacyHashBasedUpdate();
+                }
+            )
+        ));
+    }
+
+    private function runLegacyHashBasedUpdate() {
         /*
          * Check if update is necessary
          */
@@ -35,7 +49,6 @@ class update_database {
             $pdr_database_version_hash = $row->pdr_database_version_hash;
             error_log("Read pdr_database_version_hash from database: " . $pdr_database_version_hash . PHP_EOL, 3, PDR_FILE_SYSTEM_APPLICATION_PATH . 'maintenance.log');
         }
-        require_once PDR_FILE_SYSTEM_APPLICATION_PATH . 'src/php/database_version_hash.php';
         error_log("Read PDR_DATABASE_VERSION_HASH from file: " . PDR_DATABASE_VERSION_HASH . PHP_EOL, 3, PDR_FILE_SYSTEM_APPLICATION_PATH . 'maintenance.log');
         if (PDR_DATABASE_VERSION_HASH === $pdr_database_version_hash) {
             /*
@@ -67,7 +80,7 @@ class update_database {
         $message = date('Y-m-d') . ': ' . 'Write new pdr_database_version_hash into the database:' . PHP_EOL;
         error_log($message, 3, PDR_FILE_SYSTEM_APPLICATION_PATH . 'maintenance.log');
         $sql_query = 'REPLACE INTO `pdr_self` (`pdr_database_version_hash`) VALUES (:pdr_database_version_hash);';
-        $result = database_wrapper::instance()->run($sql_query, array(
+        database_wrapper::instance()->run($sql_query, array(
             'pdr_database_version_hash' => PDR_DATABASE_VERSION_HASH
         ));
         $message = date('Y-m-d') . ': ' . 'Done with update_database' . PHP_EOL;


### PR DESCRIPTION
### Motivation
- Introduce a simple migration framework to replace ad-hoc legacy `update_database()` execution and persist applied migrations. 
- Provide safe, idempotent application of legacy hash-based updates with a DB-level lock to avoid concurrent runs.

### Description
- Add `MigrationInterface` to standardize migration objects with `getVersion()`, `getDescription()` and `up()` methods.
- Add `MigrationRunner` which creates a `schema_migrations` table, uses `GET_LOCK`/`RELEASE_LOCK` to serialize runs, checks `isApplied()`, executes `up()` and records applied migrations with `markAsApplied()`.
- Add `LegacyHashBridgeMigration` implementing `MigrationInterface` that wraps a callable and returns success as a boolean for compatibility with existing legacy update logic.
- Update `update_database` to instantiate ` PDR\Database\Migration\MigrationRunner` and run a single `LegacyHashBridgeMigration` named `legacy-hash-<PDR_DATABASE_VERSION_HASH>` which delegates to the previous `runLegacyHashBasedUpdate()` function, and remove the duplicated `require_once` call.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba727c270c832686d7d5267e6c13f6)