### PR TITLE
Add `getSafeUserData` and `getMyUserData` endpoint for authenticated user info

### DIFF
--- a/src/php/classes/PDR/Api/Controllers/UserController.php
+++ b/src/php/classes/PDR/Api/Controllers/UserController.php
@@ -46,4 +46,25 @@ class UserController extends BaseController {
             $this->sendError($e->getMessage());
         }
     }
+    /**
+     * Returns the currently authenticated user as safe JSON data.
+     */
+    public function getMyUserData() {
+        try {
+            if (!$this->session->user_is_logged_in()) {
+                $this->sendError('Not authenticated', 401);
+            }
+
+            $currentUser = $this->session->getUserObject();
+            if (!$currentUser instanceof \user) {
+                $this->sendError('Not authenticated', 401);
+            }
+
+            $userData = $currentUser->getSafeUserData();
+            $this->sendJson($userData, 200);
+        } catch (Exception $e) {
+            $this->sendError($e->getMessage());
+        }
+    }
+
 }

--- a/src/php/classes/class.user.php
+++ b/src/php/classes/class.user.php
@@ -451,6 +451,26 @@ class user {
         database_wrapper::instance()->run($sql_query, array('user_name' => $this->user_name));
     }
 
+
+    /**
+     * Returns all non-sensitive user data as an associative array.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSafeUserData(): array {
+        return [
+            'primary_key' => $this->primary_key,
+            'employee_key' => $this->employee_key,
+            'user_name' => $this->user_name,
+            'email' => $this->email,
+            'status' => $this->status,
+            'receive_emails_on_changed_roster' => $this->receive_emails_on_changed_roster,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'privileges' => is_array($this->privileges) ? $this->privileges : [],
+        ];
+    }
+
     public function getJsonData() {
         $publicData = [
             'primary_key' => $this->primary_key,


### PR DESCRIPTION
### Motivation

- Provide a safe, centralized representation of user data that excludes sensitive fields for API responses.
- Expose an endpoint to return the currently authenticated user's data while enforcing authentication and proper HTTP status codes.

### Description

- Added `getSafeUserData` to `class.user.php` which returns a non-sensitive associative array of user fields including `primary_key`, `employee_key`, `user_name`, `email`, `status`, timestamps, and `privileges`.
- Implemented `getMyUserData` in `UserController.php` which verifies authentication via the session, returns `401` using `sendError` when unauthenticated, and returns safe user data with `sendJson` when authenticated.
- Existing user JSON helpers remain unchanged and `getSafeUserData` is used to satisfy previous calls that expected a safe data representation.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a046bde25d48323abb2c175d25ec038)